### PR TITLE
relax opentelemetry requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ aiohttp_cors>=0.7,<2.0
 aiokafka>=0.8.0,<0.9.0
 click>=6.7,<8.2
 mode-streaming>=0.3.0
-opentelemetry-api==1.16.0
+opentelemetry-api>=1.12.0
 terminaltables>=3.1,<4.0
 yarl>=1.0,<2.0
 croniter>=0.3.16


### PR DESCRIPTION
relax opentelemetry requirements  to allow for passing of faust-tests

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust-streaming.github.io/faust/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
